### PR TITLE
Added alternative value for transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/*
+vendor/*

--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
 Transform Encoder Module for Caddy's Logger
 ===============================================
 
-This module adds logging encoder named `transform`. The module accepts a `template` with the placeholders are surrounded by
-braces `{}` and filled by values extracted from the stucture of the JSON log encoder. The JSON configuration looks like this:
-```json
-{
-	"encoder": "transform",
-	"template": "{...}"
-}
-```
-
-The nesting is traversed using `>`. For example, to print the `uri` field, the traversal is templated as `{request>uri}`.
+This module adds logging encoder named `transform`. The module accepts a `template` with the placeholders are surrounded
+by
+braces `{}` and filled by values extracted from the stucture of the JSON log encoder. The JSON configuration looks like
+this:
 
 ```json
 {
-	"request": {
-		"method": "GET",
-		"uri": "/",
-		"proto": "HTTP/2.0",
-		...
+  "encoder": "transform",
+  "template": "{...}"
 }
 ```
 
-The Caddyfile configuration accepts the template immediately following the encoder name, and can be ommitted to assume Apache Common Log Format.
+The nesting is traversed using `>`. For example, to print the `uri` field, the traversal is templated as `{request>uri}`
+.
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "uri": "/",
+    "proto": "HTTP/2.0",
+    ...
+  }
+```
+
+The Caddyfile configuration accepts the template immediately following the encoder name, and can be ommitted to assume
+Apache Common Log Format.
 
 ```caddyfile
 log {
@@ -41,11 +46,13 @@ log {
 }
 ```
 
-The syntax of `template` is defined by the package [github.com/buger/jsonparser](https://github.com/buger/jsonparser). Objects are traversed using the key name. Arrays can be traversed by using the format `[index]`, as in `[0]`. For example, to get the first element in the `User-Agent` array, the template is `{request>headers>User-Agent>[0]}`.
+The syntax of `template` is defined by the package [github.com/buger/jsonparser](https://github.com/buger/jsonparser).
+Objects are traversed using the key name. Arrays can be traversed by using the format `[index]`, as in `[0]`. For
+example, to get the first element in the `User-Agent` array, the template is `{request>headers>User-Agent>[0]}`.
 
 ## Examples
 
-### Apache Common Log Format Example 
+### Apache Common Log Format Example
 
 The module comes with one special value of `{common_log}` for the Apache Common Log format to simplify configuration
 
@@ -70,6 +77,22 @@ format transform `{request>remote_addr} - {request>user_id} [{ts}] "{request>met
         time_format "02/Jan/2006:15:04:05 -0700"
 }
 ```
+
+# Alternative value
+
+You can use an alternative value by using the following syntax `{val1:val2}`. For example, to show the `X-Forwarded-For`
+header as `remote_addr` replacement you can do the following
+
+```caddy
+format transform `{request>headers>X-Forwarded-For[0]:request>remote_ip} - {request>user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size} "{request>headers>Referer>[0]}" "{request>headers>User-Agent>[0]}"` {
+        time_format "02/Jan/2006:15:04:05 -0700"
+}
+```
+
+The character `:` act as indicator for alternative value if the preceding key is not set.
+
+For example, `{request>headers>X-Forwarded-For[0]:request>remote_ip}` means that if `X-Forwarded-For` first array value
+is not empty use that otherwise fallback on `remote_addr`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ format transform `{request>headers>X-Forwarded-For[0]:request>remote_ip} - {requ
 
 The character `:` act as indicator for alternative value if the preceding key is not set.
 
-For example, `{request>headers>X-Forwarded-For[0]:request>remote_ip}` means that if `X-Forwarded-For` first array value
-is not empty use that otherwise fallback on `remote_addr`.
+For example, `{request>headers>X-Forwarded-For>[0]:request>remote_ip}` means that if `X-Forwarded-For` first array value is not empty use that otherwise fallback on `remote_addr`.
 
 ## Install
 

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -152,6 +152,16 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "transform: multiple argument with alternative value.",
+			fields: fields{
+				Template: "{obj1>obj2>[0]:-obj3[0]} - {obj3>[2]:-obj1>obj2>[0]}",
+			},
+			args: args{
+				d: caddyfile.NewTestDispenser(`transform {obj1>obj2>[0]:-obj3[0]} - {obj3>[2]:-obj1>obj2>[0]}`),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/formatencoder.go
+++ b/formatencoder.go
@@ -117,20 +117,18 @@ func (se TransformEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field
 		return buf, err
 	}
 	repl.Map(func(key string) (interface{}, bool) {
-		path := strings.Split(key, ">")
-		value, dataType, _, err := jsonparser.Get(buf.Bytes(), path...)
-		if err != nil {
+		if strings.Contains(key, ":-") {
+			for _, slice := range strings.Split(key, ":-") {
+				val, noerr := getValue(buf, slice)
+				if noerr {
+					return val, noerr
+				}
+			}
+			// No match found.
 			return nil, false
 		}
-		switch dataType {
-		case jsonparser.NotExist:
-			return nil, false
-		case jsonparser.Array, jsonparser.Boolean, jsonparser.Null, jsonparser.Number, jsonparser.Object, jsonparser.String, jsonparser.Unknown:
-			// if a value exists, return it as is. A byte is a byte is a byte. The replacer handles them just fine.
-			return value, true
-		default:
-			return nil, false
-		}
+
+		return getValue(buf, key)
 	})
 
 	out := repl.ReplaceAll(se.Template, se.Placeholder)
@@ -144,6 +142,23 @@ func (se TransformEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field
 		buf.AppendByte('\n')
 	}
 	return buf, err
+}
+
+func getValue(buf *buffer.Buffer, key string) (interface{}, bool) {
+	path := strings.Split(key, ">")
+	value, dataType, _, err := jsonparser.Get(buf.Bytes(), path...)
+	if err != nil {
+		return nil, false
+	}
+	switch dataType {
+	case jsonparser.NotExist:
+		return nil, false
+	case jsonparser.Array, jsonparser.Boolean, jsonparser.Null, jsonparser.Number, jsonparser.Object, jsonparser.String, jsonparser.Unknown:
+		// if a value exists, return it as is. A byte is a byte is a byte. The replacer handles them just fine.
+		return value, true
+	default:
+		return nil, false
+	}
 }
 
 var _ caddy.Module = (*TransformEncoder)(nil)

--- a/formatencoder.go
+++ b/formatencoder.go
@@ -117,11 +117,11 @@ func (se TransformEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field
 		return buf, err
 	}
 	repl.Map(func(key string) (interface{}, bool) {
-		if strings.Contains(key, ":-") {
-			for _, slice := range strings.Split(key, ":-") {
-				val, noerr := getValue(buf, slice)
-				if noerr {
-					return val, noerr
+		if strings.Contains(key, ":") {
+			for _, slice := range strings.Split(key, ":") {
+				val, found := getValue(buf, slice)
+				if found {
+					return val, found
 				}
 			}
 			// No match found.


### PR DESCRIPTION
as we discussed in https://github.com/caddyserver/caddy/issues/4924

This pull request add support for alternative transformer variables using the following syntax `{var:-alt1:-alt2:-etc}`