### PR TITLE
Added alternative installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,9 @@ Then build Caddy with this Go module plugged in. For example:
 $ xcaddy build --with github.com/caddyserver/transform-encoder
 ```
 
+Alternatively, Caddy 2.4.4 and up supports adding a module directly:
+```shell
+$ caddy add-package github.com/caddyserver/transform-encoder
+```
+
+Note that in all cases Caddy should be stopped and started to get the module loaded, and future updates should be conducted through either xcaddy (if built with xcaddy) or `caddy upgrade` (if added with `add-package`).


### PR DESCRIPTION
Caddy release [2.4.4](https://github.com/caddyserver/caddy/releases/tag/v2.4.4) added the ability to install modules through the `caddy add-package` command.  This pull request adds documentation on how to use that command to install this module.  For some users, this may be more streamlined than installing and using xcaddy (see Caddy [#4148](https://github.com/caddyserver/caddy/issues/4148) and [#5050](https://github.com/caddyserver/caddy/issues/5050))