### PR TITLE
Changed `{request>user_id}` to `{user_id}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The module comes with one special value of `{common_log}` for the Apache Common 
 The more spelled out way of doing it is:
 
 ```caddyfile
-format transform `{request>remote_ip} - {request>user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size}` {
+format transform `{request>remote_ip} - {user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size}` {
 	time_format "02/Jan/2006:15:04:05 -0700"
 }
 ```
@@ -65,7 +65,7 @@ format transform `{request>remote_ip} - {request>user_id} [{ts}] "{request>metho
 The more spelled out way of doing it is:
 
 ```caddy
-format transform `{request>remote_ip} - {request>user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size} "{request>headers>Referer>[0]}" "{request>headers>User-Agent>[0]}"` {
+format transform `{request>remote_ip} - {user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size} "{request>headers>Referer>[0]}" "{request>headers>User-Agent>[0]}"` {
         time_format "02/Jan/2006:15:04:05 -0700"
 }
 ```
@@ -76,7 +76,7 @@ You can use an alternative value by using the following syntax `{val1:val2}`. Fo
 header as `remote_ip` replacement you can do the following
 
 ```caddy
-format transform `{request>headers>X-Forwarded-For>[0]:request>remote_ip} - {request>user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size} "{request>headers>Referer>[0]}" "{request>headers>User-Agent>[0]}"` {
+format transform `{request>headers>X-Forwarded-For>[0]:request>remote_ip} - {user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size} "{request>headers>Referer>[0]}" "{request>headers>User-Agent>[0]}"` {
         time_format "02/Jan/2006:15:04:05 -0700"
 }
 ```

--- a/formatencoder.go
+++ b/formatencoder.go
@@ -33,7 +33,7 @@ func init() {
 const (
 	// commonLogFormat is the common log format. https://en.wikipedia.org/wiki/Common_Log_Format
 	commonLogEmptyValue = "-"
-	commonLogFormat     = `{request>remote_ip} ` + commonLogEmptyValue + ` {request>user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size}`
+	commonLogFormat     = `{request>remote_ip} ` + commonLogEmptyValue + ` {user_id} [{ts}] "{request>method} {request>uri} {request>proto}" {status} {size}`
 	commonLogTimeFormat = "02/Jan/2006:15:04:05 -0700"
 
 	commonLogFormatShortcut = `{common_log}`


### PR DESCRIPTION
The `{request>user_id}` used in the README of this plugin as well as in the definition of `commonLogFormat` is not returning the value that represents `"user_id": "foobar"` in the JSON access logs / the value of the placeholder `http.auth.user.id`.

I am not sure why `{request>user_id}` was used, but `{user_id}` works for me in case of `basic_auth` usage or using the new functionality described here https://github.com/caddyserver/caddy/pull/6108

For me, `{user_id}`  instead of `{request>user_id}`  makes sense because the `user_id` is on the same level as `ts` (`{ts}`), `status` ( `{status}`) or `size` (`{size}`) as described in https://caddyserver.com/docs/logging#structured-logs

```json
{
	"level": "info",
	"ts": 1646861401.5241024,
	"logger": "http.log.access",
	"msg": "handled request",
	"request": {
		"remote_ip": "127.0.0.1",
		"remote_port": "41342",
		"client_ip": "127.0.0.1",
		"proto": "HTTP/2.0",
		"method": "GET",
		"host": "localhost",
		"uri": "/",
		"headers": {
			"User-Agent": ["curl/7.82.0"],
			"Accept": ["*/*"],
			"Accept-Encoding": ["gzip, deflate, br"],
		},
		"tls": {
			"resumed": false,
			"version": 772,
			"cipher_suite": 4865,
			"proto": "h2",
			"server_name": "example.com"
		}
	},
	"bytes_read": 0,
	"user_id": "",
	"duration": 0.000929675,
	"size": 10900,
	"status": 200,
	"resp_headers": {
		"Server": ["Caddy"],
		"Content-Encoding": ["gzip"],
		"Content-Type": ["text/html; charset=utf-8"],
		"Vary": ["Accept-Encoding"]
	}
}
```

This PR fixes the README and the definition of `commonLogFormat`.

